### PR TITLE
FIXED missing import of <string> in linux_process_load.hpp

### DIFF
--- a/lib/linux_process_load.hpp
+++ b/lib/linux_process_load.hpp
@@ -13,6 +13,7 @@
 #include <tuple>
 #include <map>
 #include <unordered_map>
+#include <string>
 
 class linuxProcessLoad {
 


### PR DESCRIPTION
This was giving error on 'cmake --build . --target linuxmonitoring' on Ubuntu with cmake 3.18.4
