### PR TITLE
Fix compilation error

### DIFF
--- a/lib/linux_systemutil.cpp
+++ b/lib/linux_systemutil.cpp
@@ -31,7 +31,7 @@ int64_t linuxUtil::getTemperature(const std::string &thermalZone) {
     int64_t temperature;
     std::string line;
     while (std::getline(temperatureFile, line)) {
-        scanf(line.c_str(), "%ld", &temperature);
+        sscanf(line.c_str(), "%lld", &temperature);
     }
     temperatureFile.close();
     return temperature;


### PR DESCRIPTION
The first time I tried to compile I got this error:

```
[ 42%] Building CXX object CMakeFiles/linuxmonitoring.dir/lib/linux_systemutil.cpp.o
D:/code/libs/Linux-System-Monitoring-Library/lib/linux_systemutil.cpp: In static member function 'static int64_t linuxUtil::getTemperature(const string&)':
D:/code/libs/Linux-System-Monitoring-Library/lib/linux_systemutil.cpp:34:14: error: ignoring return value of 'int scanf(const char*, ...)' declared with attribute 'warn_unused_result' [-Werror=unused-result]
   34 |         scanf(line.c_str(), "%ld", &temperature);
      |         ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus.exe: all warnings being treated as errors
```
The error was a bit obscure but I found out that the problem was that it was supposed to use `sscanf` not `scanf`. We don't want to read data from stdin, but from a null-terminated character string buffer.

After fixing the problem, I got this one:
```
[ 33%] Building CXX object CMakeFiles/linuxmonitoring.dir/lib/linux_systemutil.cpp.o
D:/code/libs/Linux-System-Monitoring-Library/lib/linux_systemutil.cpp: In static member function 'static int64_t linuxUtil::getTemperature(const string&)':
D:/code/libs/Linux-System-Monitoring-Library/lib/linux_systemutil.cpp:34:33: error: format '%ld' expects argument of type 'long int*', but argument 3 has type 'int64_t*' {aka 'long long int*'} [-Werror=format=]
   34 |         sscanf(line.c_str(), "%ld", &temperature);
      |                               ~~^   ~~~~~~~~~~~~
      |                                 |   |
      |                                 |   int64_t* {aka long long int*}
      |                                 long int*
      |                               %lld
cc1plus.exe: all warnings being treated as errors
```
If we want to use a 64-bit integer, it needs to be `%lld`.

Let me know if you want me fix those errors in another way.

By the way, I was using _arm-poky-linux-gnueabi-g++.exe_ (GCC) 10.2.0