### PR TITLE
Give the possibility to use static library

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,11 +1,11 @@
 
 cmake_minimum_required(VERSION 3.0)
 
-SET(BUILD_SHARED_LIBS ON)
+option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 set(LIBRARY_OUTPUT_PATH "${CMAKE_BINARY_DIR}/lib")
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/)
-add_library(linuxmonitoring SHARED
+add_library(linuxmonitoring
             ${CMAKE_CURRENT_LIST_DIR}/linux_memoryload.cpp
             ${CMAKE_CURRENT_LIST_DIR}/linux_networkload.cpp
             ${CMAKE_CURRENT_LIST_DIR}/linux_systemutil.cpp


### PR DESCRIPTION
This PR will give the possibility to generate a static library. The shared libraries are kept by default. So this should not change the current behavior but will be more flexible allowing `cmake -DBUILD_SHARED_LIBS=OFF`

References:
* https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html
* https://cmake.org/cmake/help/latest/command/add_library.html
* https://cmake.org/cmake/help/latest/guide/tutorial/Selecting%20Static%20or%20Shared%20Libraries.html